### PR TITLE
add timeago package/fix debian error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Michael J. Stealey <stealey@renci.org>
 ENV DEBIAN_FRONTEND noninteractive
 ENV PY_SAX_PARSER=hs_core.xmlparser
 
-RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y \
     apt-transport-https \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Michael J. Stealey <stealey@renci.org>
 ENV DEBIAN_FRONTEND noninteractive
 ENV PY_SAX_PARSER=hs_core.xmlparser
 
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y \
     apt-transport-https \
     ca-certificates \

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,6 +142,7 @@ strict-rfc3339==0.7
 suds-jurko==0.6
 swagger-spec-validator==2.3.1
 tzlocal==1.2.2
+timeago==1.0.10
 uritemplate==3.0.0
 validate-email==1.3
 virtualenv==15.0.2


### PR DESCRIPTION
Explanation to the line added to Dockerfile:
`RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list`

### There was a build error from debian. @phuongdm and I adopted a solution from the site below. It worked.

https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease

Sending build context to Docker daemon  220.2kB
Step 1/25 : FROM python:2.7.11
---> a047e3d0ae2b
Step 2/25 : MAINTAINER Michael J. Stealey <stealey@renci.org>
---> Using cache
---> e7e2ca8d2e29
Step 3/25 : ENV DEBIAN_FRONTEND noninteractive
---> Using cache
---> d7391566cc2a
Step 4/25 : ENV PY_SAX_PARSER=hs_core.xmlparser
---> Using cache
---> d7ffa9bb9db8
Step 5/25 : RUN apt-get update && apt-get install -y     apt-transport-https     ca-certificates    sudo     && apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D     && curl -sLhttps://deb.nodesource.com/setup_7.x | sudo -E bash -
---> Running in 680444bb029c
Get:1 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://httpredir.debian.org jessie InRelease
Get:2 http://httpredir.debian.org jessie-updates InRelease [7340 B]
Get:3 http://httpredir.debian.org jessie Release.gpg [2420 B]
Get:4 http://httpredir.debian.org jessie Release [148 kB]
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [832 kB]
Get:6 http://httpredir.debian.org jessie/main amd64 Packages [9098 kB]
Fetched 10.1 MB in 29s (342 kB/s)
 _W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)
 
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update && apt-get install -y     apt-transport-https     ca-certificates     sudo     && apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D     && curl -sLhttps://deb.nodesource.com/setup_7.x | sudo -E bash -' returned a non-zero code: 100_
 
