### PR TITLE
update dependencies with known security issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # generated using pipdeptree https://github.com/tox-dev/pipdeptree
 # pipdeptree -f | sed 's/ //g' | sort -u > requirements.txt
 aiohttp==3.8.3
-amqp==2.6.1
+amqp==5.1.1
 anyjson==0.3.3
 arrow==0.7.0
 asgiref==3.5.2
@@ -14,7 +14,7 @@ bcrypt==4.0.1
 beautifulsoup4==4.11.1
 billiard==3.6.4.0
 bleach==4.1.0
-celery==4.4.7
+celery==5.2.7
 certifi==2022.12.7
 cffi==1.15.1
 cftime==1.6.2
@@ -66,10 +66,10 @@ exceptiongroup==1.0.4
 filebrowser-safe==1.1.1
 flake8==6.0.0
 flex==6.14.1
-flower==0.9.3
+flower==1.2.0
 foresite@git+https://github.com/sblack-usu/foresite-toolkit.git@94c0c2a8e21a922caa1df6cc412d5dc1a7adb189#subdirectory=foresite-python/trunk
 funcsigs==1.0.2
-future==0.16.0
+future==0.18.3
 GDAL==2.4.1
 geographiclib==1.52
 geojson==1.3.2
@@ -92,7 +92,7 @@ jsonschema==2.6.0
 jwcrypto==1.4.2
 keepalive==0.5
 kiwisolver==1.4.4
-kombu==4.6.11
+kombu==5.2.4
 lazy-object-proxy==1.8.0
 lxml==4.9.2
 Markdown==3.0.1
@@ -170,7 +170,7 @@ ua-parser==0.16.1
 uritemplate==3.0.0
 urllib3==1.26.13
 validate-email==1.3
-vine==1.3.0
+vine==5.0.0
 virtualenv==15.0.2
 webencodings==0.5.1
 websocket-client==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ django-crispy-forms==1.13.0
 django-debug-toolbar==3.2.4
 django-freshly==0.1.2
 django-haystack==3.1.1
+django-health-check==3.17.0
 django-heartbeat==2.1.0
 django-ipware==2.1.0
 django-jsonfield==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,7 +105,7 @@ nameparser==0.5.7
 netCDF4==1.5.1.2
 nose==1.3.7
 nose-timer==0.7.6
-numpy==1.24.1
+numpy==1.16.6
 oauthlib==3.1.0
 OWSLib==0.10.3
 packaging==21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ amqp==2.6.1
 anyjson==0.3.3
 arrow==0.7.0
 asgiref==3.5.2
-astroid==1.4.9
+astroid==2.12.13
 attrs==22.1.0
 autopep8==1.2.2
 Babel==2.11.0
@@ -42,7 +42,7 @@ django-crispy-forms==1.13.0
 django-debug-toolbar==3.2.4
 django-freshly==0.1.2
 django-haystack==3.1.1
-django-heartbeat==2.0.2
+django-heartbeat==2.1.0
 django-ipware==2.1.0
 django-jsonfield==1.4.1
 django-modeltranslation==0.12.2
@@ -79,14 +79,14 @@ grappelli-safe==1.1.1
 greenlet==2.0.1
 gunicorn==20.1.0
 hsmodels@git+https://github.com/hydroshare/hsmodels.git@3197b512d2764e2a4772596fe6c288331e53223e
-html5lib==0.9999999
+html5lib==1.1
 idna==3.4
 inflection==0.3.1
 iniconfig==1.1.1
 ipaddress==1.0.22
 isodate==0.5.4
 itypes==1.2.0
-Jinja2==2.10.1
+Jinja2==3.1.2
 jsonpointer==1.14
 jsonschema==2.6.0
 jwcrypto==1.4.2
@@ -94,7 +94,7 @@ keepalive==0.5
 kiwisolver==1.4.4
 kombu==4.6.11
 lazy-object-proxy==1.8.0
-lxml==4.4.0
+lxml==4.9.2
 Markdown==3.0.1
 MarkupSafe==2.0.1
 matplotlib==3.1.2
@@ -105,7 +105,7 @@ nameparser==0.5.7
 netCDF4==1.5.1.2
 nose==1.3.7
 nose-timer==0.7.6
-numpy==1.16.6
+numpy==1.24.1
 oauthlib==3.1.0
 OWSLib==0.10.3
 packaging==21.3
@@ -118,7 +118,7 @@ pluggy==1.0.0
 prettytable==0.7.2
 probableparsing==0.0.1
 probablepeople==0.5.4
-psutil==4.0.0
+psutil==5.9.4
 psycopg2==2.9.5
 pyasn1==0.4.4
 pycodestyle==2.10.0
@@ -128,7 +128,7 @@ pydantic==1.10.2
 pydebug==1.0.3
 pyflakes==3.0.1
 PyLD==2.0.3
-pylint==1.5.5
+pylint==2.15.9
 PyNaCl==1.5.0
 pyparsing==3.0.9
 pyproj==3.4.0
@@ -141,7 +141,7 @@ python-dateutil==2.8.0
 python-irodsclient==0.8.1
 pytz==2022.6
 pytz-deprecation-shim==0.1.0.post0
-PyYAML==5.3
+PyYAML==6.0
 rcssmin==1.1.0
 rdflib==5.0.0
 redis==2.10.5


### PR DESCRIPTION
This PR updates python dependencies that have known security issues, to the extent possible.

There are still some deps with security warnings that I was not able to update. Most notably:
- rdflib (requires hsmodels update)
- gdal (requires base image OS upgrade from buster -> bullseye, which requires iRods upgrade)
- numpy (pending gdal upgrade and associated modifications in HS)
- setuptools (pending gdal upgrade)
- Django (pending Mezzanine upgrade)