### PR TITLE
Revert "Bump cryptography from 39.0.1 to 41.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ colorama==0.4.6
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==6.5.0
-cryptography==41.0.0
+cryptography==39.0.1
 cycler==0.10.0
 debugpy==1.6.4
 deepdiff==1.7.0


### PR DESCRIPTION
Reverts hydroshare/hs_docker_base#90